### PR TITLE
Cleanup of dead links

### DIFF
--- a/website/config/BCExam .json
+++ b/website/config/BCExam .json
@@ -1,8 +1,0 @@
-{
-  "link": "BCExam ",
-  "title": "",
-  "autoCrawledTitle": "Exam MB-800: Microsoft Dynamics 365 Business Central Functional Consultant - Certifications | Microsoft Learn",
-  "keywords": "",
-  "category": "dynamics365",
-  "url": "https://learn.microsoft.com/en-us/learn/certifications/exams/mb-800"
-}

--- a/website/config/az204.json
+++ b/website/config/az204.json
@@ -1,8 +1,0 @@
-{
-  "link": "az204",
-  "title": null,
-  "autoCrawledTitle": "Exam AZ-204: Developing Solutions for Microsoft Azure - Certifications | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://learn.microsoft.com/en-us/learn/certifications/exams/az-204"
-}

--- a/website/config/azuretraincertdeck.json
+++ b/website/config/azuretraincertdeck.json
@@ -1,8 +1,0 @@
-{
-  "link": "AzureTrainCertDeck",
-  "title": null,
-  "autoCrawledTitle": "",
-  "keywords": null,
-  "category": "learn",
-  "url": "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4J5ea"
-}

--- a/website/config/blockchain.json
+++ b/website/config/blockchain.json
@@ -1,8 +1,0 @@
-{
-  "link": "blockchain",
-  "title": null,
-  "autoCrawledTitle": "",
-  "keywords": null,
-  "category": null,
-  "url": "https://microsoft.sharepoint.com/teams/BlockchainAsAService/SitePages/Home.aspx"
-}

--- a/website/config/enrollios.json
+++ b/website/config/enrollios.json
@@ -1,8 +1,0 @@
-{
-  "link": "enrolliOS",
-  "title": null,
-  "autoCrawledTitle": "Set up iOS device access to your company resources | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://learn.microsoft.com/en-us/intune-user-help/enroll-your-device-in-intune-ios"
-}

--- a/website/config/gcguardrails.json
+++ b/website/config/gcguardrails.json
@@ -1,8 +1,0 @@
-{
-  "link": "gcguardrails",
-  "title": null,
-  "autoCrawledTitle": "GitHub - Azure/GuardrailsSolutionAccelerator: This reference implementation is based on the 30-days guardrails requirements as part of the GC Cloud Operationalization Framework, it offers an automated way to verify if the department has implemented the recommended controls provided by Treasury Board of Canada Secretariat (TBS) and display the results in a comprehensive format.",
-  "keywords": null,
-  "category": "azure",
-  "url": "https://github.com/azure/GuardrailsSolutionAccelerator"
-}

--- a/website/config/holdatownhall.json
+++ b/website/config/holdatownhall.json
@@ -1,8 +1,0 @@
-{
-  "link": "HoldaTownhall",
-  "title": null,
-  "autoCrawledTitle": "404 - Content Not Found | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://learn.microsoft.com/SharePoint/hold-town-hall-using-yammer?branch=dom-hub2"
-}

--- a/website/config/informationprotectiondocs.json
+++ b/website/config/informationprotectiondocs.json
@@ -1,8 +1,0 @@
-{
-  "link": "InformationProtectionDocs",
-  "title": null,
-  "autoCrawledTitle": "Search - Microsoft Community Hub",
-  "keywords": null,
-  "category": null,
-  "url": "https://techcommunity.microsoft.com/t5/forums/searchpage/tab/message?advanced=false&allow_punctuation=false&q=information%20protection"
-}

--- a/website/config/mcaspoc.json
+++ b/website/config/mcaspoc.json
@@ -1,8 +1,0 @@
-{
-  "link": "MCASpoc",
-  "title": null,
-  "autoCrawledTitle": "Browse code samples | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://gallery.technet.microsoft.com/Cloud-App-Security-Proof-2fa94be8"
-}

--- a/website/config/scannershowcase.json
+++ b/website/config/scannershowcase.json
@@ -1,8 +1,0 @@
-{
-  "link": "ScannerShowcase",
-  "title": null,
-  "autoCrawledTitle": "Automating data protection with Azure Information Protection scanner - Inside Track Blog",
-  "keywords": null,
-  "category": null,
-  "url": "https://www.microsoft.com/itshowcase/Article/Content/1070/Automating-data-protection-with-Azure-Information-Protection-scanner"
-}

--- a/website/config/scicertifications.json
+++ b/website/config/scicertifications.json
@@ -1,8 +1,0 @@
-{
-  "link": "SCICertifications",
-  "title": null,
-  "autoCrawledTitle": "Browse Certifications and Exams | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://learn.microsoft.com/en-us/learn/certifications/browse/?resource_type=certification&products=azure%2Cm365&terms=SC-&expanded=azure%2Cm365"
-}

--- a/website/config/securitycerts_cybersecarchitectexpert.json
+++ b/website/config/securitycerts_cybersecarchitectexpert.json
@@ -1,8 +1,0 @@
-{
-  "link": "SecurityCerts_CybersecArchitectExpert",
-  "title": null,
-  "autoCrawledTitle": "Microsoft Certified: Cybersecurity Architect Expert - Certifications | Microsoft Learn",
-  "keywords": null,
-  "category": null,
-  "url": "https://learn.microsoft.com/en-us/learn/certifications/cybersecurity-architect-expert/"
-}

--- a/website/config/turnonbce.json
+++ b/website/config/turnonbce.json
@@ -1,8 +1,0 @@
-{
-  "link": "TurnOnBCE",
-  "title": null,
-  "autoCrawledTitle": "Admin Controls",
-  "keywords": null,
-  "category": null,
-  "url": "https://www.bing.com/business/bceadmin"
-}

--- a/website/config/wip4studentambassadors.json
+++ b/website/config/wip4studentambassadors.json
@@ -1,8 +1,0 @@
-{
-  "link": "wip4studentambassadors",
-  "title": null,
-  "autoCrawledTitle": "The Windows Insider Program for Student Ambassadors",
-  "keywords": null,
-  "category": null,
-  "url": "https://insider.windows.com/studentambassadors?utm_source=social&utm_medium=mslearnsa_teamschannel&utm_campaign=wip_sa_announcement"
-}


### PR DESCRIPTION
As per https://github.com/merill/aka/pull/3026

Removes 
https://aka.ms/az204
https://aka.ms/AzureTrainCertDeck
https://aka.ms/BCExam
https://aka.ms/blockchain
https://aka.ms/enrolliOS
https://aka.ms/gcguardrails
https://aka.ms/HoldaTownhall
https://aka.ms/InformationProtectionDocs
https://aka.ms/MCASpoc
https://aka.ms/ScannerShowcase
https://aka.ms/SCICertifications
https://aka.ms/SecurityCerts_CybersecArchitectExpert
https://aka.ms/TurnOnBCE
https://aka.ms/wip4studentambassadors